### PR TITLE
Make it compatible with yubikey manager 5.x.x

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,8 +8,8 @@ pylint = "*"
 twine = "*"
 
 [packages]
-awsume = "*"
-yubikey-manager = "*"
+awsume = "==4.*"
+yubikey-manager = "==5.*"
 
 [requires]
 python_version = "3"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='awsume-yubi-plugin',
     packages=find_packages(),
-    version='0.1.2',
+    version='0.2.1',
     entry_points={
         'awsume': [
             'yubi = yubi'
@@ -18,7 +18,7 @@ setup(
     license='MIT',
     url='https://github.com/kylejwatson/awsume-yubi-plugin',
     install_requires=[
-        'awsume',
-        'yubikey-manager',
+        'awsume~=4.5.4',
+        'yubikey-manager~=5.3.0',
     ]
 )


### PR DESCRIPTION
This PR addresses a couple of things

Compatibility:
* Using a new way to connect to devices
* Versions of dependencies have been restricted

General improvements:
* Now, the cached session will be refreshed if the user passes `-r` argument
* Checking `mfa_serial` from source profile